### PR TITLE
Update OLCalibrateOOC.m

### DIFF
--- a/MatlabPrograms/OLCalibrateOOC.m
+++ b/MatlabPrograms/OLCalibrateOOC.m
@@ -54,20 +54,7 @@ spectroRadiometerOBJ = [];
 
 try
     % Ask which type of calibration we're doing.
-    calTypes = enumeration('OLCalibrationTypes');
-    while true
-        fprintf('- Available calibration types:\n');
-        
-        for i = 1:length(calTypes)
-            fprintf('%d: %s\n', i, calTypes(i).char);
-        end
-        
-        x = GetInput('Selection', 'number', 1);
-        if x >= 1 && x <= length(calTypes)
-            break;
-        end
-    end
-    selectedCalType = calTypes(x);
+    selectedCalType = OLGetCalibrationEnumerationType;
     
     if strfind(selectedCalType.char, 'BoxA')
         whichBox = 'BoxA';


### PR DESCRIPTION
This replaces the enumeration structure with a simple call to `OLGetCalibrationEnumerationType`, which does the same but is a separate function and is used in many other programs