### PR TITLE
Harmonize photoreceptor classes in SST

### DIFF
--- a/OLApproachSupport/OLApproachSupportUtilties/OLEstimateConePhotopigmentFractionBleached.m
+++ b/OLApproachSupport/OLApproachSupportUtilties/OLEstimateConePhotopigmentFractionBleached.m
@@ -54,8 +54,8 @@ photopicLuminanceCdM2 = T_xyz(2,:)*radianceWattsPerM2Sr;
 chromaticityXY = T_xyz(1:2,:)*radianceWattsPerM2Sr/sum(T_xyz*radianceWattsPerM2Sr);
 
 %% Get cone spectral sensitivities to use to compute isomerization rates
-[T_cones, T_quantalIsom] = GetHumanPhotoreceptorSS(S, {'LCone' 'MCone' 'SCone'}, fieldSizeDegrees, observerAgeInYears, pupilDiameterMm, [], []);
-%[T_conesHemo, T_quantalIsomHemo]  = GetHumanPhotoreceptorSS(S, {'LConeHemo' 'MConeHemo' 'SConeHemo'}, fieldSizeDegrees, observerAgeInYears, pupilDiameterMm, [], []);
+[T_cones, T_quantalIsom] = GetHumanPhotoreceptorSS(S, {'LConeTabulatedAbsorbance' 'MConeTabulatedAbsorbance' 'SConeTabulatedAbsorbance'}, fieldSizeDegrees, observerAgeInYears, pupilDiameterMm, [], []);
+[T_conesHemo, T_quantalIsomHemo]  = GetHumanPhotoreceptorSS(S, {'LConeTabulatedAbsorbancePenumbral' 'MConeTabulatedAbsorbancePenumbral' 'SConeTabulatedAbsorbancePenumbral'}, fieldSizeDegrees, observerAgeInYears, pupilDiameterMm, [], []);
 
 %% Compute irradiance, trolands, etc.
 pupilAreaMm2 = pi*((pupilDiameterMm/2)^2);


### PR DESCRIPTION
I recently updated the function `GetHumanPhotoreceptorSS` in the SilentSubstitutionToolbox to resolve various unsupported and outdated spectral sensitivity types. The function `OLEstimateConePhotopigmentFractionBleached` called for the cone types `LCone`, `MCone`, `SCone`, `LConeHemo`, `MConeHemo`, and `SConeHemo`. These, which were constructed from the Stockman-Sharpe nomograms, are now legacy functions in the `GetHumanPhotoreceptorSS` as we believe that the ones constructed from tabulated absorbances (`{L, M, S}ConeTabulatedAbsorbance` and `{L|M|S}ConeTabulatedAbsorbancePenumbral`) do a better job.

I've therefore removed any references to the old nomogram-constructed cone fundamentals, and use the tabulated ones. It is worth noting that the fraction pigment bleached will likely be different between the two spectral sensitivities, but these differences are directly related to how well the nomogram spectral sensitivities fit the tabulated ones.